### PR TITLE
Minor fix, allowing errors to be bubbled up to errorBacks on queued commands

### DIFF
--- a/txconnpool/pool.py
+++ b/txconnpool/pool.py
@@ -291,7 +291,7 @@ class Pool(object):
 
             _ign_d = self.performRequest(method, *args, **kwargs)
 
-            _ign_d.addCallback(d.callback)
+            _ign_d.chainDeferred(d)
 
 
     def suggestMaxClients(self, maxClients):


### PR DESCRIPTION
i.e. without this if the server goes away you will see an error like:

Unhandled error in Deferred:
Unhandled Error
Traceback (most recent call last
