### PR TITLE
Disregard pending connections when shutting down

### DIFF
--- a/txconnpool/pool.py
+++ b/txconnpool/pool.py
@@ -134,12 +134,18 @@ class Pool(object):
         self._pendingConnects = 0
         self._commands = []
 
-    def _isIdle(self):
+
+    def _hasNoClients(self):
         return (
             len(self._busyClients) == 0 and
-            len(self._commands) == 0 and
-            self._pendingConnects == 0
-        )
+            len(self._commands) == 0)
+
+
+    def _isIdle(self):
+        return (
+            self._hasNoClients() and
+            self._pendingConnects == 0)
+
 
     def _shutdownCallback(self):
         self.shutdown_requested = True
@@ -149,7 +155,7 @@ class Pool(object):
         for client in self._freeClients:
             client.transport.loseConnection()
         
-        if self._isIdle():
+        if self._hasNoClients():
             return None
         
         self.shutdown_deferred = Deferred()


### PR DESCRIPTION
I've run into an issue where my Twisted process does not successfully shut down, the reactor is stopped but the process never (or takes a really long time to) exits. Some investigation revealed that the shutdown callback returns `shutdown_deferred` even when there are only pending connections (and no client connections), ultimately resulting in `shutdown_deferred` not being called back and so Twisted waits on it for shutdown.

I opted for performing a more lenient idle check in the shutdown callback instead of threading my through the connector and factory callbacks.
